### PR TITLE
Dockerized the application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+data

--- a/Provider.Dockerfile
+++ b/Provider.Dockerfile
@@ -1,0 +1,13 @@
+FROM node:8
+WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app/
+COPY /dataPresenter /usr/src/app/dataPresenter
+COPY /src /usr/src/app/src
+
+RUN npm install
+RUN npm run build
+
+CMD ["node", "./dataPresenter/scripts/dataProvider.js", "TestSignal", "TestSignal"]
+
+

--- a/Server.Dockerfile
+++ b/Server.Dockerfile
@@ -1,0 +1,13 @@
+FROM node:8
+WORKDIR /usr/src/app
+COPY package.json /usr/src/app/
+COPY /dataPresenter /usr/src/app/dataPresenter
+COPY /src /usr/src/app/src
+
+RUN npm install
+RUN npm run build
+
+EXPOSE 1337
+CMD ["npm", "start"]
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "2"
+services:
+  data_server:
+    container_name: data_server
+    restart: always
+    build: 
+      context: .
+      dockerfile: Server.Dockerfile
+    ports:
+      - "1337:1337"
+  data_presenter:
+    container_name: data_presenter
+    restart: always
+    build:
+      context: .
+      dockerfile: Provider.Dockerfile
+  mongo:
+    container_name: mongo
+    image: mongo
+    volumes:
+      - ./data:/data/db
+    ports:
+      - "27017:27017"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "socket.io-client":"^1.7.2"
     },
     "scripts": {
-        "build": "babel src -d dataPresenter/scripts"
+        "build": "babel src -d dataPresenter/scripts",
+        "start": "node dataPresenter/scripts/dataServer.js"
     }
 }

--- a/src/dataProvider.js
+++ b/src/dataProvider.js
@@ -49,7 +49,7 @@ var IntrouduceYourself = function(signalDetails){
 }
 
 //Server connection part:
-var socket = io.connect('http://127.0.0.1:1337');
+var socket = io.connect('http://data_server:1337');
 
 socket.on('connect', function (socket) {
     logger('Connection with server established');


### PR DESCRIPTION
Dockerized the application:
- docker image for data server and presenter
- docker-compose to spawn containers with dataServer, dataPresenter and mongo

Current setup:
- docker container with dataServer communicates with mongo service and exposes 1337 port to external (it is possible to browse docker-hosted application from local OS browser)
- docker container with dataProvoder communicates with dataServer by docker-compose networkin mechanism - exposed by host name defined in yml file